### PR TITLE
Improve usability in generic programming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ macro_rules! ct_eq_gen {
              *  remain 0x01 or 0x00.
              */
             let val = z as u8;
-            unsafe{trans(val)}
+            unsafe{trans::<u8,bool>(val)}
         }
         #[test]
         fn $test_name() {
@@ -254,7 +254,7 @@ macro_rules! ct_select_gen {
         #[no_mangle]
         #[inline(never)]
         pub extern "C" fn $name(flag: bool, x: $code, y: $code) -> $code {
-            let val: u8 = unsafe{trans(flag)};
+            let val: u8 = unsafe{trans::<bool,u8>(flag)};
             let flag = val as $code;
             (($max ^ flag.wrapping_sub(1))&x)|(flag.wrapping_sub(1)&y)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,11 @@ fn test_bool_representation() {
 }
 
 pub trait ConstantTimeEq {
-    fn ct_eq( x: Self, y: Self ) -> bool;
+    fn ct_eq(x: Self, y: Self) -> bool;
+}
+pub fn ct_eq<T>(x: T, y: T) -> bool
+  where T: ConstantTimeEq {
+    <T as ConstantTimeEq>::ct_eq(x,y)
 }
 
 /*
@@ -247,6 +251,10 @@ ct_eq_slice_gen!(ct_usize_slice_eq,usize;;
 pub trait ConstantTimeSelect {
     fn ct_select(flag: bool, x: Self, y: Self) -> Self;
 }
+pub fn ct_select<T>(flag: bool, x: T, y: T) -> T
+  where T: ConstantTimeSelect {
+    <T as ConstantTimeSelect>::ct_select(flag,x,y)
+}
 
 macro_rules! ct_select_gen {
     ($name:ident,$max:expr,$code:ty;;$test_name:ident,$v0:expr,$v1:expr) => {
@@ -307,6 +315,10 @@ ct_select_gen!(ct_select_usize,MAX_USIZE,usize;;
 
 pub trait ConstantTimeCopy : Sized {
     fn ct_copy(flag: bool, x: &mut [Self], y: &[Self]);
+}
+pub fn ct_copy<T>(flag: bool, x: &mut [T], y: &[T])
+  where T: ConstantTimeCopy {
+    <T as ConstantTimeCopy>::ct_copy(flag,x,y);
 }
 
 macro_rules! ct_constant_copy_gen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,24 +161,24 @@ macro_rules! ct_eq_gen {
         fn $test_name() {
             let x: $code = $test_v0;
             let y: $code = $test_v1;
-            assert_eq!( $name($max,$max), true);
-            assert_eq!( $name(x,x), true);
-            assert_eq!( $name(y,y), true);
-            assert_eq!( $name(0,0), true);
-            assert_eq!( $name(1,1), true);
-            assert_eq!( $name($max,0), false);
-            assert_eq!( $name($max,1), false);
-            assert_eq!( $name($max,x), false);
-            assert_eq!( $name($max,y), false);
-            assert_eq!( $name(y,1), false);
-            assert_eq!( $name(x,1), false);
-            assert_eq!( $name(y,0), false);
-            assert_eq!( $name(x,0), false);
-            assert_eq!( $name(x,y), false);
+            assert_eq!( ct_eq($max,$max), true);
+            assert_eq!( ct_eq(x,x), true);
+            assert_eq!( ct_eq(y,y), true);
+            assert_eq!( ct_eq::<$code>(0,0), true);
+            assert_eq!( ct_eq::<$code>(1,1), true);
+            assert_eq!( ct_eq::<$code>($max,0), false);
+            assert_eq!( ct_eq::<$code>($max,1), false);
+            assert_eq!( ct_eq($max,x), false);
+            assert_eq!( ct_eq($max,y), false);
+            assert_eq!( ct_eq(y,1), false);
+            assert_eq!( ct_eq(x,1), false);
+            assert_eq!( ct_eq(y,0), false);
+            assert_eq!( ct_eq(x,0), false);
+            assert_eq!( ct_eq(x,y), false);
             $(
-                assert_eq!( $name($shr,$shr), true);
-                assert_eq!( $name($shr,0), false);
-                assert_eq!( $name($shr,$max), false);
+                assert_eq!( ct_eq::<$code>($shr,$shr), true);
+                assert_eq!( ct_eq::<$code>($shr,0), false);
+                assert_eq!( ct_eq::<$code>($shr,$max), false);
             )*
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,9 +354,9 @@ macro_rules! ct_constant_copy_gen {
             let base: [$code;10] = [0,0,0,0,0,0,0,0,0,0];
             let mut x: [$code;10] = [0,0,0,0,0,0,0,0,0,0];
             let y: [$code;10] = [$max,$max,$max,$max,$max,$max,$max,$max,$max,$max];
-            $name(false,&mut x, &y);
+            ct_copy(false,&mut x, &y);
             assert_eq!( $sl_eq(&x,&base), true);
-            $name(true,&mut x, &y);
+            ct_copy(true,&mut x, &y);
             assert_eq!( $sl_eq(&x,&base), false);
             assert_eq!( $sl_eq(&x,&y), true);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,14 @@ ct_eq_gen!(ct_usize_eq,usize,MAX_USIZE,16,8,4,2,1;;
 ct_eq_gen!(ct_usize_eq,usize,MAX_USIZE,32,16,8,4,2,1;;
     test_ct_usize_eq, 859632175648921456, 5);
 
+pub trait ConstantTimeEqSlice : Sized {
+    fn ct_eq_slice(x: &[Self], y: &[Self]) -> bool;
+}
+pub fn ct_eq_slice<T>(x: &[T], y: &[T]) -> bool
+  where T: ConstantTimeEqSlice {
+    <T as ConstantTimeEqSlice>::ct_eq_slice(x,y)
+}
+
 macro_rules! ct_eq_slice_gen {
     ($name:ident,$code: ty;;$test_name:ident,$max: expr) => {
         ///Check the equality of slices.
@@ -219,20 +227,20 @@ macro_rules! ct_eq_slice_gen {
             }
             <$code as ConstantTimeEq>::ct_eq(flag,0)
         }
-        impl<'a> ConstantTimeEq for &'a [$code] {
-            fn ct_eq( x: &'a [$code], y: &'a [$code]) -> bool { $name(x,y) }
+        impl ConstantTimeEqSlice for $code {
+            fn ct_eq_slice( x: &[$code], y: &[$code]) -> bool { $name(x,y) }
         }
         #[test]
         fn $test_name() {
             let x: [$code;10] = [0,0,0,0,0,0,0,0,0,0];
             let y: [$code;10] = [$max,$max,$max,$max,$max,$max,$max,$max,$max,$max];
             let z: [$code;10] = [1,1,1,1,1,1,1,1,1,1];
-            assert_eq!( $name( &x, &x), true);
-            assert_eq!( $name( &y, &y), true);
-            assert_eq!( $name( &z, &z), true);
-            assert_eq!( $name( &x, &y), false);
-            assert_eq!( $name( &x, &y), false);
-            assert_eq!( $name( &y, &z), false);
+            assert_eq!( ct_eq_slice( &x, &x), true);
+            assert_eq!( ct_eq_slice( &y, &y), true);
+            assert_eq!( ct_eq_slice( &z, &z), true);
+            assert_eq!( ct_eq_slice( &x, &y), false);
+            assert_eq!( ct_eq_slice( &x, &y), false);
+            assert_eq!( ct_eq_slice( &y, &z), false);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,18 +285,18 @@ macro_rules! ct_select_gen {
         }
         #[test]
         fn $test_name() {
-            assert_eq!( $name(true,$v0,$v1), $v0);
-            assert_eq!( $name(false,$v0,$v1), $v1);
-            assert_eq!( $name(true,$v1,$v0), $v1);
-            assert_eq!( $name(false,$v1,$v0), $v0);
-            assert_eq!( $name(true,$v0,$max), $v0);
-            assert_eq!( $name(false,$v0,$max), $max);
-            assert_eq!( $name(true,$max,$v0), $max);
-            assert_eq!( $name(false,$max,$v0), $v0);
-            assert_eq!( $name(true,$max,$v1), $max);
-            assert_eq!( $name(false,$max,$v1), $v1);
-            assert_eq!( $name(true,$v1,$max), $v1);
-            assert_eq!( $name(false,$v1,$max), $max);
+            assert_eq!( ct_select::<$code>(true,$v0,$v1), $v0);
+            assert_eq!( ct_select::<$code>(false,$v0,$v1), $v1);
+            assert_eq!( ct_select::<$code>(true,$v1,$v0), $v1);
+            assert_eq!( ct_select::<$code>(false,$v1,$v0), $v0);
+            assert_eq!( ct_select::<$code>(true,$v0,$max), $v0);
+            assert_eq!( ct_select::<$code>(false,$v0,$max), $max);
+            assert_eq!( ct_select::<$code>(true,$max,$v0), $max);
+            assert_eq!( ct_select::<$code>(false,$max,$v0), $v0);
+            assert_eq!( ct_select::<$code>(true,$max,$v1), $max);
+            assert_eq!( ct_select::<$code>(false,$max,$v1), $v1);
+            assert_eq!( ct_select::<$code>(true,$v1,$max), $v1);
+            assert_eq!( ct_select::<$code>(false,$v1,$max), $max);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,11 @@ ct_select_gen!(ct_select_u64,MAX_U64,u64;;
 ct_select_gen!(ct_select_usize,MAX_USIZE,usize;;
     test_ct_select_usize,155,4);
 
+
+pub trait ConstantTimeCopy : Sized {
+    fn ct_copy(flag: bool, x: &mut [Self], y: &[Self]);
+}
+
 macro_rules! ct_constant_copy_gen {
     ($name:ident,$max:expr,$code:ty
     ;;$test_name:ident,$sl_eq:ident,$other_test:ident) => {
@@ -328,6 +333,9 @@ macro_rules! ct_constant_copy_gen {
                 let x_temp = x[i].clone();
                 x[i] = <$code as ConstantTimeSelect>::ct_select(flag,y_temp,x_temp);
             }
+        }
+        impl ConstantTimeCopy for $code {
+            fn ct_copy(flag: bool, x: &mut [$code], y: &[$code]) { $name(flag,x,y) }
         }
         #[test]
         fn $test_name() {


### PR DESCRIPTION
These commits improve the `ct_*` functions usability when programming generically over unsigned numeric types, i.e. they make the functions slightly prettier.  They also shave off a few macro arguments, possibly making the code easier to read.  

I have not understood why you use `#[no_mangle] extern "C"` functions ala https://github.com/valarauca/consistenttime/issues/5 so I built the traits as wrappers around those.  I'd prefer to consolidate these four traits into one or two however, but that requires a less local medication to the source, so I felt it was worth running this pull request by you first.

There are several places were the `concat_idents!()` macro might help keep the source modifications more local, but it's not stable or very readable. 

Additional unanswered questions : Should this use `Borrow<[T]>` anyplace?  